### PR TITLE
perf: use a mutable vec to reduce allocation

### DIFF
--- a/batch-copy-derive/src/lib.rs
+++ b/batch-copy-derive/src/lib.rs
@@ -67,8 +67,8 @@ fn derive_impl(input: DeriveInput) -> syn::Result<TokenStream2> {
         .map(|f| f.ident.as_ref().unwrap())
         .collect();
 
-    let boxes = field_idents.iter().map(|id| {
-        quote! { ::std::boxed::Box::from(&self.#id) }
+    let pushes = field_idents.iter().map(|id| {
+        quote! { out.push(&self.#id as &(dyn ::batch_copy::__private::ToSql + Sync)); }
     });
 
     let ddl_infos: Vec<(String, bool)> = fields
@@ -102,8 +102,8 @@ fn derive_impl(input: DeriveInput) -> syn::Result<TokenStream2> {
             const TYPES: &'static [::batch_copy::__private::Type] = &[
                 #(#pg_types),*
             ];
-            fn binary_copy_vec(&self) -> ::std::vec::Vec<::std::boxed::Box<dyn ::batch_copy::__private::ToSql + Sync + Send + '_>> {
-                vec![#(#boxes),*]
+            fn fill_copy_refs<'a>(&'a self, out: &mut ::std::vec::Vec<&'a (dyn ::batch_copy::__private::ToSql + Sync)>) {
+                #(#pushes)*
             }
         }
     })

--- a/batch-copy/src/actor.rs
+++ b/batch-copy/src/actor.rs
@@ -71,27 +71,15 @@ where
         pin_mut!(writer);
 
         let mut errors = false;
-        for row in target_rows.into_iter() {
-            let result = {
-                // We own the row here, surely there's a better way to do this
-                // without intermediate Vecs - TODO
-                let boxes = row.binary_copy_vec();
-                let row_refs: Vec<&_> = boxes
-                    .iter()
-                    .map(|x| {
-                        // Convert the to a dyn reference
-                        &**x as &(dyn ToSql + Sync)
-                    })
-                    .collect();
-
-                writer.as_mut().write(row_refs.as_slice()).await
-            };
-
-            if let Err(e) = result {
+        let mut row_refs: Vec<&(dyn ToSql + Sync)> = Vec::with_capacity(T::TYPES.len());
+        for row in target_rows.iter() {
+            row_refs.clear();
+            row.fill_copy_refs(&mut row_refs);
+            if let Err(e) = writer.as_mut().write(row_refs.as_slice()).await {
                 log::error!("Error in COPY:\n\t{e}");
                 errors = true;
                 break;
-            };
+            }
         }
 
         if !errors {

--- a/batch-copy/src/lib.rs
+++ b/batch-copy/src/lib.rs
@@ -30,5 +30,5 @@ pub trait BatchCopyRow {
     const CHECK_STATEMENT: &'static str;
     const DDL_STATEMENT: &'static str;
 
-    fn binary_copy_vec(&self) -> Vec<Box<dyn ToSql + Sync + Send + '_>>;
+    fn fill_copy_refs<'a>(&'a self, out: &mut Vec<&'a (dyn ToSql + Sync)>);
 }


### PR DESCRIPTION
previously `row.binary_copy_vec()` allocated a `Vec<Box<dyn ToSql + Sync + Send>>` — one `Box` per field (heap-allocating a fat pointer just to deref it) plus a `Vec`

Instead use a mutable Vec pattern and reuse it in the loop, with a new `fill_copy_refs` fn
